### PR TITLE
Add webserver to listen for HTTP POST requests and forward them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use python:3.9-slim as the base image
+FROM python:3.9-slim
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy requirements.txt to the working directory
+COPY requirements.txt .
+
+# Install the dependencies using pip
+RUN pip install -r requirements.txt
+
+# Copy the rest of the application code to the working directory
+COPY . .
+
+# Set the command to run the Flask app
+CMD ["python", "spotbot.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # spotbot
+
+## Description
+
+Spotbot is a simple webserver that listens for HTTP POST requests and forwards the content of those requests to another URL via another HTTP POST request. It is built using Flask.
+
+## Requirements
+
+- Python 3.x
+- Flask
+- requests
+
+## Installation
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/tblanarik/spotbot.git
+   cd spotbot
+   ```
+
+2. Install the required dependencies:
+   ```sh
+   pip install -r requirements.txt
+   ```
+
+## Running the Webserver
+
+To run the webserver, execute the following command:
+```sh
+python spotbot.py
+```
+
+The webserver will start and listen on port 5000.
+
+## Sending a POST Request to the `/forward` Endpoint
+
+To send a POST request to the `/forward` endpoint, you can use a tool like `curl` or Postman. Here is an example using `curl`:
+
+```sh
+curl -X POST http://localhost:5000/forward -H "Content-Type: application/json" -d '{"key": "value"}'
+```
+
+Replace `{"key": "value"}` with the actual JSON content you want to send.
+
+## Running the Webserver using Docker
+
+To run the webserver using Docker, follow these steps:
+
+1. Build the Docker image:
+   ```sh
+   docker build -t spotbot .
+   ```
+
+2. Run the Docker container:
+   ```sh
+   docker run -p 5000:5000 spotbot
+   ```
+
+The webserver will start and listen on port 5000 inside the Docker container.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/spotbot.py
+++ b/spotbot.py
@@ -1,0 +1,14 @@
+from flask import Flask, request
+import requests
+
+app = Flask(__name__)
+
+@app.route('/forward', methods=['POST'])
+def forward():
+    content = request.get_json()
+    target_url = 'http://example.com/target'  # Replace with the actual target URL
+    response = requests.post(target_url, json=content)
+    return response.text, response.status_code
+
+if __name__ == '__main__':
+    app.run(port=5000)


### PR DESCRIPTION
Add a webserver to listen for HTTP POST requests and forward the content to another URL.

* **spotbot.py**: Create a Flask app that listens on port 5000 and defines a `/forward` endpoint to accept POST requests and forward the content to a specified target URL.
* **requirements.txt**: Add `Flask` and `requests` as dependencies.
* **README.md**: Add project description, installation instructions, how to run the webserver, how to send a POST request to the `/forward` endpoint, and how to run the webserver using Docker.
* **Dockerfile**: Create a Dockerfile to build a Docker image for the webserver using `python:3.9-slim` as the base image, install dependencies, and set the command to run the Flask app.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tblanarik/spotbot?shareId=c68e1fea-caf9-4dff-8823-92815173e429).