### PR TITLE
Adds deeplinks to SOTA and POTA sites

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -43,8 +43,8 @@ def create_spot_deeplink(source, fullCallsign, wwffRef):
 
     match source:
         case "sotawatch":
-            return "[See their latest spot](https://sotl.as/activators/{fullCallsign})"
+            return f"[See their latest spot](https://sotl.as/activators/{fullCallsign})"
         case "pota":
-            return "[See their latest spot](https://api.pota.app/spot/comments/{fullCallsign}/{wwffRef})"
+            return f"[See their latest spot](https://api.pota.app/spot/comments/{fullCallsign}/{wwffRef})"
         case _:
             return ""

--- a/function_app.py
+++ b/function_app.py
@@ -29,7 +29,7 @@ def create_content(req_body):
     summitRef = req_body.get('summitRef', '')
     wwffRef = req_body.get('wwffRef', '')
 
-    content = {"content": f"{fullCallsign} | {source} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef}"}
+    content = {"content": f"{fullCallsign} | {source} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef}", "flags": 4}
     return content
 
 def call_target(content):

--- a/function_app.py
+++ b/function_app.py
@@ -31,6 +31,7 @@ def create_content(req_body):
 
     spot_deeplink = create_spot_deeplink(source, fullCallsign, wwffRef)
 
+    # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
     content = {"content": f"{fullCallsign} | {source} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {spot_deeplink}", "flags": 4}
     return content
 
@@ -40,7 +41,6 @@ def call_target(content):
     return func.HttpResponse(response.text, status_code=response.status_code)
 
 def create_spot_deeplink(source, fullCallsign, wwffRef):
-
     match source:
         case "sotawatch":
             return f"[See their latest spot](https://sotl.as/activators/{fullCallsign})"

--- a/function_app.py
+++ b/function_app.py
@@ -29,10 +29,22 @@ def create_content(req_body):
     summitRef = req_body.get('summitRef', '')
     wwffRef = req_body.get('wwffRef', '')
 
-    content = {"content": f"{fullCallsign} | {source} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef}", "flags": 4}
+    spot_deeplink = create_spot_deeplink(source, fullCallsign, wwffRef)
+
+    content = {"content": f"{fullCallsign} | {source} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {spot_deeplink}", "flags": 4}
     return content
 
 def call_target(content):
     target_url = os.getenv('TARGET_URL')
     response = requests.post(target_url, json=content)
     return func.HttpResponse(response.text, status_code=response.status_code)
+
+def create_spot_deeplink(source, fullCallsign, wwffRef):
+
+    match source:
+        case "sotawatch":
+            return "[See their latest spot](https://sotl.as/activators/{fullCallsign})"
+        case "pota":
+            return "[See their latest spot](https://api.pota.app/spot/comments/{fullCallsign}/{wwffRef})"
+        case _:
+            return ""

--- a/test.py
+++ b/test.py
@@ -6,13 +6,13 @@ class TestSpotBot(unittest.TestCase):
     def test_function_app_basic(self):
         req_body = {"fullCallsign": "KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
         content = function_app.create_content(req_body)
-        expected = {'content': 'KI7HSG | pota | freq: 14.074 | mode: FT8 | loc: US-0052'}
+        expected = {'content': 'KI7HSG | pota | freq: 14.074 | mode: FT8 | loc: US-0052 | [See their latest spot](https://api.pota.app/spot/comments/KI7HSG/US-0052)', 'flags': 4}
         self.assertDictEqual(content, expected)
 
     def test_function_app(self):
         req_body = {"fullCallsign": "KI7HSG", "source": "sotawatch", "frequency": "14.074", "mode": "FT8", "summitRef": "ABCD"}
         content = function_app.create_content(req_body)
-        expected = {'content': 'KI7HSG | sotawatch | freq: 14.074 | mode: FT8 | loc: ABCD'}
+        expected = {'content': 'KI7HSG | sotawatch | freq: 14.074 | mode: FT8 | loc: ABCD | [See their latest spot](https://sotl.as/activators/KI7HSG)', 'flags': 4}
         self.assertDictEqual(content, expected)
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -4,9 +4,9 @@ import function_app
 class TestSpotBot(unittest.TestCase):
 
     def test_function_app_basic(self):
-        req_body = {"fullCallsign": "KI7HSG", "source": "POTA", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
+        req_body = {"fullCallsign": "KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
         content = function_app.create_content(req_body)
-        expected = {'content': 'KI7HSG | POTA | freq: 14.074 | mode: FT8 | loc: US-0052'}
+        expected = {'content': 'KI7HSG | pota | freq: 14.074 | mode: FT8 | loc: US-0052'}
         self.assertDictEqual(content, expected)
 
     def test_function_app(self):


### PR DESCRIPTION
This pull request introduces a new feature to include a deep link in the content generated by the `create_content` function and updates the corresponding tests to validate this new functionality. The main changes involve adding a new function to generate the deep link and modifying the content structure to include this link.