### PR TITLE
accounts for callsigns with modifiers when generating url

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -23,13 +23,14 @@ def spotbot(req: func.HttpRequest) -> func.HttpResponse:
 
 def create_content(req_body):
     fullCallsign = req_body.get('fullCallsign', 'Unknown')
+    callsign = req_body.get('callsign', 'Unknown')
     source = req_body.get('source', 'Unknown')
     frequency = req_body.get('frequency', 'Unknown')
     mode = req_body.get('mode', 'Unknown')
     summitRef = req_body.get('summitRef', '')
     wwffRef = req_body.get('wwffRef', '')
 
-    spot_deeplink = create_spot_deeplink(source, fullCallsign, wwffRef)
+    spot_deeplink = create_spot_deeplink(source, callsign, wwffRef)
 
     # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
     content = {"content": f"{fullCallsign} | {source} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {spot_deeplink}", "flags": 4}
@@ -40,11 +41,11 @@ def call_target(content):
     response = requests.post(target_url, json=content)
     return func.HttpResponse(response.text, status_code=response.status_code)
 
-def create_spot_deeplink(source, fullCallsign, wwffRef):
+def create_spot_deeplink(source, callsign, wwffRef):
     match source:
         case "sotawatch":
-            return f"[See their latest spot](https://sotl.as/activators/{fullCallsign})"
+            return f"[See their latest spot](https://sotl.as/activators/{callsign})"
         case "pota":
-            return f"[See their latest spot](https://api.pota.app/spot/comments/{fullCallsign}/{wwffRef})"
+            return f"[See their latest spot](https://api.pota.app/spot/comments/{callsign}/{wwffRef})"
         case _:
             return ""

--- a/test.py
+++ b/test.py
@@ -4,15 +4,15 @@ import function_app
 class TestSpotBot(unittest.TestCase):
 
     def test_function_app_basic(self):
-        req_body = {"fullCallsign": "KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
+        req_body = {"fullCallsign": "KI7HSG/P", "callsign":"KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
         content = function_app.create_content(req_body)
-        expected = {'content': 'KI7HSG | pota | freq: 14.074 | mode: FT8 | loc: US-0052 | [See their latest spot](https://api.pota.app/spot/comments/KI7HSG/US-0052)', 'flags': 4}
+        expected = {'content': 'KI7HSG/P | pota | freq: 14.074 | mode: FT8 | loc: US-0052 | [See their latest spot](https://api.pota.app/spot/comments/KI7HSG/US-0052)', 'flags': 4}
         self.assertDictEqual(content, expected)
 
     def test_function_app(self):
-        req_body = {"fullCallsign": "KI7HSG", "source": "sotawatch", "frequency": "14.074", "mode": "FT8", "summitRef": "ABCD"}
+        req_body = {"fullCallsign": "KI7HSG/P", "callsign":"KI7HSG", "source": "sotawatch", "frequency": "14.074", "mode": "FT8", "summitRef": "ABCD"}
         content = function_app.create_content(req_body)
-        expected = {'content': 'KI7HSG | sotawatch | freq: 14.074 | mode: FT8 | loc: ABCD | [See their latest spot](https://sotl.as/activators/KI7HSG)', 'flags': 4}
+        expected = {'content': 'KI7HSG/P | sotawatch | freq: 14.074 | mode: FT8 | loc: ABCD | [See their latest spot](https://sotl.as/activators/KI7HSG)', 'flags': 4}
         self.assertDictEqual(content, expected)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes changes to improve the handling of callsigns in the `function_app.py` and its corresponding tests. The main updates involve adding a separate `callsign` field and ensuring that this field is used consistently across the application and tests - because `callsign` does not include modifiers such as `/P`