### PR TITLE
Keeps a running log of messages, now with timestamps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 azure-functions
 azure-data-tables
 requests
+pytz

--- a/spotbot.py
+++ b/spotbot.py
@@ -27,6 +27,7 @@ def run(req):
         existingMessage = get_previous_message(messageId)
         content = existingMessage + "\n" + content
 
+    # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
     content_payload = {"content":content, "flags": 4}
 
     messageId = post_message(content_payload, messageId)
@@ -42,8 +43,7 @@ def create_content(req_body, dd):
 
     spot_deeplink = create_spot_deeplink(source, callsign, wwffRef)
     formatted_time = dd.strftime("%H:%M")
-    # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
-    #content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}", "flags": 4}
+
     content = f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}"
     return content
 

--- a/spotbot.py
+++ b/spotbot.py
@@ -8,7 +8,7 @@ import tables
 
 def run(req):
     logging.info('Python HTTP trigger function processed a request.')
-    dd = datetime.now(timezone('US/Pacific'))
+    dd = datetime.datetime.now(timezone('US/Pacific'))
 
     req_body = req.get_json()
     logging.info(f"Received JSON: {req_body}")

--- a/spotbot.py
+++ b/spotbot.py
@@ -1,28 +1,36 @@
 import logging
 import os
 import datetime
+from pytz import timezone
 import requests
 import tables
 
 
 def run(req):
     logging.info('Python HTTP trigger function processed a request.')
+    dd = datetime.now(timezone('US/Pacific'))
 
     req_body = req.get_json()
     logging.info(f"Received JSON: {req_body}")
 
     callsign = req_body.get('callsign')
 
+    content = create_content(req_body)
+
     table = tables.get_table()
     entity = tables.query_for_entity(table, callsign)
     messageId = None
+    existingMessage = None
+
     if is_entity_recent(entity):
         messageId = entity['MessageId']
-    content = create_content(req_body)
-    messageId = call_target(content, messageId)
+        existingMessage = get_previous_message(messageId)
+        content = existingMessage + "\n" + content
+
+    messageId = post_message(content, messageId)
     tables.upsert_entity(table, callsign, messageId)
-    
-def create_content(req_body):
+
+def create_content(req_body, dd):
     callsign = req_body.get('callsign', 'Unknown')
     source = req_body.get('source', 'Unknown')
     frequency = req_body.get('frequency', 'Unknown')
@@ -33,7 +41,7 @@ def create_content(req_body):
     spot_deeplink = create_spot_deeplink(source, callsign, wwffRef)
 
     # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
-    content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef}", "flags": 4}
+    content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {dd.strftime("%H:%M")}", "flags": 4}
     return content
 
 def create_spot_deeplink(source, callsign, wwffRef):
@@ -44,7 +52,7 @@ def create_spot_deeplink(source, callsign, wwffRef):
             return f"[{source}](https://api.pota.app/spot/comments/{callsign}/{wwffRef})"
         case _:
             return ""
-        
+
 def is_entity_recent(entity):
     if entity is None:
         return False
@@ -53,7 +61,7 @@ def is_entity_recent(entity):
     lookback_seconds = int(os.getenv('LOOKBACK_SECONDS', 7200))
     return (cur_time - ent_time).total_seconds() < lookback_seconds
 
-def call_target(content, messageId=None):
+def post_message(content, messageId=None):
     target_url = os.getenv('TARGET_URL')
     verb = "POST"
     if messageId is not None:
@@ -61,6 +69,13 @@ def call_target(content, messageId=None):
         verb = "PATCH"
     response = requests.request(verb, url=target_url, params={"wait": "true"}, json=content)
     return extract_message_id(response)
+
+def get_previous_message(messageId):
+    target_url = os.getenv('TARGET_URL')
+    verb = "GET"
+    target_url = target_url + f"/messages/{messageId}"
+    response = requests.request(verb, url=target_url)
+    response.json()['content']
 
 def extract_message_id(response):
     return response.json()['id']

--- a/spotbot.py
+++ b/spotbot.py
@@ -15,7 +15,7 @@ def run(req):
 
     callsign = req_body.get('callsign')
 
-    content = create_content(req_body)
+    content = create_content(req_body, dd)
 
     table = tables.get_table()
     entity = tables.query_for_entity(table, callsign)

--- a/spotbot.py
+++ b/spotbot.py
@@ -39,9 +39,9 @@ def create_content(req_body, dd):
     wwffRef = req_body.get('wwffRef', '')
 
     spot_deeplink = create_spot_deeplink(source, callsign, wwffRef)
-
+    formatted_time = dd.strftime("%H:%M")
     # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
-    content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {dd.strftime("%H:%M")}", "flags": 4}
+    content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}", "flags": 4}
     return content
 
 def create_spot_deeplink(source, callsign, wwffRef):

--- a/spotbot.py
+++ b/spotbot.py
@@ -24,8 +24,8 @@ def run(req):
 
     if is_entity_recent(entity):
         messageId = entity['MessageId']
-        existingMessage = get_previous_message(messageId)
-        content = existingMessage + "\n" + content
+        existingMessage = get_previous_message(messageId).replace("~", "")
+        content = "~~" + existingMessage + "~~\n" + content
 
     # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
     content_payload = {"content":content, "flags": 4}
@@ -44,7 +44,7 @@ def create_content(req_body, dd):
     spot_deeplink = create_spot_deeplink(source, callsign, wwffRef)
     formatted_time = dd.strftime("%H:%M")
 
-    content = f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}"
+    content = f"{formatted_time} | {callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef}"
     return content
 
 def create_spot_deeplink(source, callsign, wwffRef):

--- a/spotbot.py
+++ b/spotbot.py
@@ -27,7 +27,9 @@ def run(req):
         existingMessage = get_previous_message(messageId)
         content = existingMessage + "\n" + content
 
-    messageId = post_message(content, messageId)
+    content_payload = {"content":content, "flags": 4}
+
+    messageId = post_message(content_payload, messageId)
     tables.upsert_entity(table, callsign, messageId)
 
 def create_content(req_body, dd):
@@ -41,7 +43,8 @@ def create_content(req_body, dd):
     spot_deeplink = create_spot_deeplink(source, callsign, wwffRef)
     formatted_time = dd.strftime("%H:%M")
     # flags = 4 means it will suppress embeds: https://discord.com/developers/docs/resources/message#message-object-message-flags
-    content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}", "flags": 4}
+    #content = {"content": f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}", "flags": 4}
+    content = f"{callsign} | {spot_deeplink} | freq: {frequency} | mode: {mode} | loc: {summitRef}{wwffRef} | {formatted_time}"
     return content
 
 def create_spot_deeplink(source, callsign, wwffRef):

--- a/spotbot.py
+++ b/spotbot.py
@@ -75,7 +75,7 @@ def get_previous_message(messageId):
     verb = "GET"
     target_url = target_url + f"/messages/{messageId}"
     response = requests.request(verb, url=target_url)
-    response.json()['content']
+    return response.json()['content']
 
 def extract_message_id(response):
     return response.json()['id']

--- a/test.py
+++ b/test.py
@@ -1,18 +1,22 @@
 import unittest
 import spotbot
+from datetime import datetime
+from pytz import timezone
 
 class TestSpotBot(unittest.TestCase):
 
     def test_function_app_basic(self):
+        dd = datetime.strptime("2024-10-13T01:05:03", "%Y-%m-%dT%H:%M:%S")
         req_body = {"callsign":"KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
-        content = spotbot.create_content(req_body)
-        expected = {'content': 'KI7HSG | [pota](https://api.pota.app/spot/comments/KI7HSG/US-0052) | freq: 14.074 | mode: FT8 | loc: US-0052', 'flags': 4}
+        content = spotbot.create_content(req_body, dd)
+        expected = {'content': 'KI7HSG | [pota](https://api.pota.app/spot/comments/KI7HSG/US-0052) | freq: 14.074 | mode: FT8 | loc: US-0052 | 01:05', 'flags': 4}
         self.assertDictEqual(content, expected)
 
     def test_function_app(self):
+        dd = datetime.strptime("2024-10-13T01:05:03", "%Y-%m-%dT%H:%M:%S")
         req_body = {"callsign":"KI7HSG", "source": "sotawatch", "frequency": "14.074", "mode": "FT8", "summitRef": "ABCD"}
-        content = spotbot.create_content(req_body)
-        expected = {'content': 'KI7HSG | [sotawatch](https://sotl.as/activators/KI7HSG) | freq: 14.074 | mode: FT8 | loc: ABCD', 'flags': 4}
+        content = spotbot.create_content(req_body, dd)
+        expected = {'content': 'KI7HSG | [sotawatch](https://sotl.as/activators/KI7HSG) | freq: 14.074 | mode: FT8 | loc: ABCD | 01:05', 'flags': 4}
         self.assertDictEqual(content, expected)
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -9,14 +9,14 @@ class TestSpotBot(unittest.TestCase):
         dd = datetime.strptime("2024-10-13T01:05:03", "%Y-%m-%dT%H:%M:%S")
         req_body = {"callsign":"KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
         content = spotbot.create_content(req_body, dd)
-        expected = 'KI7HSG | [pota](https://api.pota.app/spot/comments/KI7HSG/US-0052) | freq: 14.074 | mode: FT8 | loc: US-0052 | 01:05'
+        expected = '01:05 | KI7HSG | [pota](https://api.pota.app/spot/comments/KI7HSG/US-0052) | freq: 14.074 | mode: FT8 | loc: US-0052'
         self.assertEqual(content, expected)
 
     def test_function_app(self):
         dd = datetime.strptime("2024-10-13T01:05:03", "%Y-%m-%dT%H:%M:%S")
         req_body = {"callsign":"KI7HSG", "source": "sotawatch", "frequency": "14.074", "mode": "FT8", "summitRef": "ABCD"}
         content = spotbot.create_content(req_body, dd)
-        expected = 'KI7HSG | [sotawatch](https://sotl.as/activators/KI7HSG) | freq: 14.074 | mode: FT8 | loc: ABCD | 01:05'
+        expected = '01:05 | KI7HSG | [sotawatch](https://sotl.as/activators/KI7HSG) | freq: 14.074 | mode: FT8 | loc: ABCD'
         self.assertEqual(content, expected)
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -9,15 +9,15 @@ class TestSpotBot(unittest.TestCase):
         dd = datetime.strptime("2024-10-13T01:05:03", "%Y-%m-%dT%H:%M:%S")
         req_body = {"callsign":"KI7HSG", "source": "pota", "frequency": "14.074", "mode": "FT8", "wwffRef":"US-0052"}
         content = spotbot.create_content(req_body, dd)
-        expected = {'content': 'KI7HSG | [pota](https://api.pota.app/spot/comments/KI7HSG/US-0052) | freq: 14.074 | mode: FT8 | loc: US-0052 | 01:05', 'flags': 4}
-        self.assertDictEqual(content, expected)
+        expected = 'KI7HSG | [pota](https://api.pota.app/spot/comments/KI7HSG/US-0052) | freq: 14.074 | mode: FT8 | loc: US-0052 | 01:05'
+        self.assertEqual(content, expected)
 
     def test_function_app(self):
         dd = datetime.strptime("2024-10-13T01:05:03", "%Y-%m-%dT%H:%M:%S")
         req_body = {"callsign":"KI7HSG", "source": "sotawatch", "frequency": "14.074", "mode": "FT8", "summitRef": "ABCD"}
         content = spotbot.create_content(req_body, dd)
-        expected = {'content': 'KI7HSG | [sotawatch](https://sotl.as/activators/KI7HSG) | freq: 14.074 | mode: FT8 | loc: ABCD | 01:05', 'flags': 4}
-        self.assertDictEqual(content, expected)
+        expected = 'KI7HSG | [sotawatch](https://sotl.as/activators/KI7HSG) | freq: 14.074 | mode: FT8 | loc: ABCD | 01:05'
+        self.assertEqual(content, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
adds `~~` around previous messages to strikethrough.
adds timestamps in PT

![image](https://github.com/user-attachments/assets/ce01b7a4-4b56-4850-a2fa-7edce5e3932f)
