### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_hamalertspotbot(staging).yml
+++ b/.github/workflows/main_hamalertspotbot(staging).yml
@@ -71,5 +71,5 @@ jobs:
           app-name: 'hamalertspotbot'
           slot-name: 'staging'
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
-
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B299E8EC708A46F8AF72AA27F3526F58 }}
+

--- a/.github/workflows/main_hamalertspotbot(staging).yml
+++ b/.github/workflows/main_hamalertspotbot(staging).yml
@@ -72,4 +72,3 @@ jobs:
           slot-name: 'staging'
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B299E8EC708A46F8AF72AA27F3526F58 }}
-

--- a/.github/workflows/main_hamalertspotbot(staging).yml
+++ b/.github/workflows/main_hamalertspotbot(staging).yml
@@ -50,8 +50,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      contents: read
+    permissions:
+
+      contents: read
+
     
     steps:
       - name: Download artifact from build job
@@ -69,4 +71,5 @@ jobs:
           app-name: 'hamalertspotbot'
           slot-name: 'staging'
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B299E8EC708A46F8AF72AA27F3526F58 }}

--- a/.github/workflows/main_hamalertspotbot(staging).yml
+++ b/.github/workflows/main_hamalertspotbot(staging).yml
@@ -50,6 +50,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     
     steps:
       - name: Download artifact from build job


### PR DESCRIPTION
Potential fix for [https://github.com/tblanarik/spotbot/security/code-scanning/6](https://github.com/tblanarik/spotbot/security/code-scanning/6)

To fix the problem, we need to add a `permissions` block to the `deploy` job in `.github/workflows/main_hamalertspotbot(staging).yml`. The block should specify the least privileges required for the job to function. For most deployment jobs, read access to `contents` is sufficient unless the job needs to write to issues, pull requests, or other resources. Since the `deploy` job downloads artifacts and deploys to Azure Functions, but does not appear to need write access to the repository, we can set `contents: read` as the minimal permission. The change should be made directly under the `deploy:` job definition, at the same indentation level as `runs-on` and `needs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
